### PR TITLE
working! (at least not same error, and with no visible errors)

### DIFF
--- a/NextGenSoftware.Holochain.HoloNET.Client.Core/Data/HoloNETRequest.cs
+++ b/NextGenSoftware.Holochain.HoloNET.Client.Core/Data/HoloNETRequest.cs
@@ -7,13 +7,13 @@ namespace NextGenSoftware.Holochain.HoloNET.Client.Core
     //[Serializable]
     public class HoloNETRequest
     {
-        [Key(0)]
+        [Key("id")]
         public ulong id { get; set; }
 
-        [Key(1)]
+        [Key("type")]
         public string type { get; set; }
 
-        [Key(2)]
+        [Key("data")]
         public byte[] data { get; set; }
 
         /*


### PR DESCRIPTION
@dellams 

The issue was with serialization, as expected, but it was hard to troubleshoot!

I figured it out though. 

I got the repo running with VS, then spun up the `happ-build-tutorial` code.

I used `RUST_LOG=trace hc sandbox generate workdir/happ --run=8888` in `happ-build-tutorial` to get extra logging, and found the raw bytes being sent:
```
[147, 1, 167, 82, 101, 113, 117, 101, 115, 116, 196, 197, 146, 169, 122, 111, 109, 101, 95, 99, 97, 108, 108, 150, 146, 196, 53, 117, 104, 67, 65, 107, 116, 95, 99, 78, 71, 121, 89, 74, 90, 73, 112, 48, 56, 98, 50, 90, 122, 120, 111, 69, 54, 69, 113, 80, 110, 100, 82, 80, 98, 95, 87, 119, 106, 86, 107, 77, 95, 109, 79, 66, 99, 70, 121, 113, 55, 122, 67, 119, 196, 53, 117, 104, 67, 48, 107, 84, 77, 105, 120, 84, 71, 48, 108, 78, 90, 67, 70, 52, 83, 90, 102, 81, 77, 71, 111, 122, 102, 50, 87, 102, 106, 81, 104, 116, 55, 69, 48, 54, 95, 119, 121, 51, 104, 50, 57, 45, 122, 80, 112, 87, 120, 80, 81, 166, 119, 104, 111, 97, 109, 105, 166, 119, 104, 111, 97, 109, 105, 196, 2, 145, 10, 192, 196, 53, 117, 104, 67, 48, 107, 84, 77, 105, 120, 84, 71, 48, 108, 78, 90, 67, 70, 52, 83, 90, 102, 81, 77, 71, 111, 122, 102, 50, 87, 102, 106, 81, 104, 116, 55, 69, 48, 54, 95, 119, 121, 51, 104, 50, 57, 45, 122, 80, 112, 87, 120, 80, 81]
```
stick these values into here: 
https://kawanet.github.io/msgpack-lite/

It gives:
```
[
  1,
  "Request",
  {
    "type": "Buffer",
    "data": [
      146,
      ...
    ]
]
```

You'll see it's serialized as an array.  It looked wrong to me, and to be sure I used the same trick to trace a Zome call request I knew to be working, in another project: 
```
[131, 162, 105, 100, 206, 0, 1, 98, 47, 164, 116, 121, 112, 101, 167, 82, 101, 113, 117, 101, 115, 116, 164, 100, 97, 116, 97, 196, 231, 130, 164, 116, 121, 112, 101, 180, 122, 111, 109, 101, 95, 99, 97, 108, 108, 95, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 164, 100, 97, 116, 97, 134, 163, 99, 97, 112, 192, 167, 99, 101, 108, 108, 95, 105, 100, 146, 196, 39, 132, 45, 36, 200, 236, 13, 140, 15, 128, 170, 148, 218, 53, 230, 172, 4, 230, 104, 194, 170, 28, 190, 28, 222, 234, 151, 234, 138, 193, 216, 1, 49, 204, 133, 12, 78, 55, 137, 166, 196, 39, 132, 32, 36, 49, 216, 88, 193, 72, 89, 30, 98, 8, 157, 11, 45, 182, 98, 127, 25, 54, 6, 57, 107, 12, 58, 193, 123, 94, 183, 22, 194, 159, 206, 39, 160, 127, 239, 177, 155, 169, 122, 111, 109, 101, 95, 110, 97, 109, 101, 166, 122, 111, 109, 101, 95, 97, 167, 102, 110, 95, 110, 97, 109, 101, 173, 102, 105, 114, 115, 116, 95, 122, 111, 109, 101, 95, 102, 110, 167, 112, 97, 121, 108, 111, 97, 100, 196, 1, 192, 170, 112, 114, 111, 118, 101, 110, 97, 110, 99, 101, 196, 39, 132, 32, 36, 49, 216, 88, 193, 72, 89, 30, 98, 8, 157, 11, 45, 182, 98, 127, 25, 54, 6, 57, 107, 12, 58, 193, 123, 94, 183, 22, 194, 159, 206, 39, 160, 127, 239, 177, 155]
```

stick that in it gives: 
```
{
  "id": 90671,
  "type": "Request",
  "data": {
    "type": "Buffer",
    "data": [
      130,
       ....
    ]
  }
}
```

so now I knew the difference. I looked up the library for MessagePack you were using: 
https://github.com/neuecc/MessagePack-CSharp

and found: https://github.com/neuecc/MessagePack-CSharp#object-serialization

that's where I saw: `[Key("foo")]`
and realized that'd be exactly what we wanted. 

Tested and it worked!

You still see this message: "ERROR holochain_websocket::websocket: Websocket: Bad message type Pong([])" but it's a non-issue. It's just the websocket client is sending "Pong" messages as an attempt to do keep-alive. It must not match the tungstenite library on the rust side though.