### PR TITLE
Update HoloNETClient.cs

### DIFF
--- a/NextGenSoftware.Holochain.HoloNET.Client.Core/HoloNETClient.cs
+++ b/NextGenSoftware.Holochain.HoloNET.Client.Core/HoloNETClient.cs
@@ -456,7 +456,7 @@ namespace NextGenSoftware.Holochain.HoloNET.Client
                     if (Config.HolochainConductorToUse == HolochainConductorEnum.HcDevTool)
                     {
                         //_conductorProcess.StartInfo.Arguments = "sandbox run 0";
-                        _conductorProcess.StartInfo.Arguments = $"hc sandbox generate {Config.FullPathToCompiledHappFolder}";
+                        _conductorProcess.StartInfo.Arguments = $"sandbox generate {Config.FullPathToCompiledHappFolder}";
                     }
 
                     _conductorProcess.StartInfo.UseShellExecute = true;


### PR DESCRIPTION
_conductorProcess.StartInfo.Arguments should not include hc, it is the command to execute specified in _conductorProcess.StartInfo.FileName

Also, this command is actually apparently starting the conductor on another port than the port 8888